### PR TITLE
Avoid crackling at high speeds.

### DIFF
--- a/src/soundproducer.c
+++ b/src/soundproducer.c
@@ -15,8 +15,12 @@
 #include "voice.h"
 #include "sink.h"
 
-
 /* Local data */
+
+/*
+* The speech rate threshold at which another algorithm is used to avoid crackling at high speeds.
+*/
+#define DECRACKLING_RATE_THRESHOLD 340
 
 /* Control data used to generate fully synthetic sounds */
 static const int16_t synth_ctrl_data[][2] =
@@ -192,36 +196,78 @@ void make_sound(soundscript_t *script, sink_t *consumer)
           else
             {
               /* Mixed and transitional sounds */
-              int16_t dx = 0;
-              while (l >= ax)
+
+              if (script->timing_rate_factor >= DECRACKLING_RATE_THRESHOLD)
                 {
-                  uint16_t next_pattern_offset;
-                  k = script->icb[stage].stretch;
-                  j = ((uint16_t)(script->sounds[i + 1].id)) & 0xFF;
-                  next_pattern_offset = script->voice->sound_offsets[j + 1];
-                  j = script->voice->sound_offsets[j];
-                  sink_put(consumer, 0);
-                  ax = (int16_t)(script->voice->samples[j]);
-                  do
+                  int16_t dx = 0;
+                  uint16_t next_j = ((uint16_t)(script->sounds[i + 1].id)) & 0xFF;
+                  uint16_t next_pattern_offset = script->voice->sound_offsets[next_j];
+                  uint16_t current_pattern_end = script->voice->sound_offsets[j] + scnt;
+
+                  while (l >= ax)
                     {
-                      ax -= (int16_t)(script->voice->samples[sidx]);
-                      ax = (int16_t)(((int32_t)ax) * ((int32_t)(dx++)) / ((int32_t)l));
-                      ax += (int16_t)(script->voice->samples[sidx++]);
-                      sink_put(consumer, (int8_t)ax);
-                      ax = ((++j) < next_pattern_offset) ? ((int16_t)(script->voice->samples[j])) : 0;
+                      k = script->icb[stage].stretch;
+                      uint16_t samples_to_process = k;
+
+                      do
+                        {
+                          if (sidx < current_pattern_end)
+                            {
+                              sink_put(consumer, script->voice->samples[sidx++]);
+                            }
+                          l--;
+                        }
+                      while ((--k) && (--scnt));
+
+                      if (scnt > 1)
+                        {
+                          l -= fading(consumer, script->voice, sidx);
+                        }
+                      dx += (samples_to_process - k);
+
+                      ax = dx + eval(&(script->icb[stage]));
+                      j = ((uint16_t)(script->sounds[i].id)) & 0xFF;
+                      sidx = script->voice->sound_offsets[j];
+                      scnt = script->voice->sound_lengths[j];
                     }
-                  while ((--k) && (--scnt));
-                  if (k)
-                    dx += silence(consumer, k);
-                  else if (scnt > 1)
-                    dx += fading(consumer, script->voice, sidx);
-                  ax = dx + eval(&(script->icb[stage]));
-                  j = ((uint16_t)(script->sounds[i].id)) & 0xFF;
-                  sidx = script->voice->sound_offsets[j];
-                  scnt = script->voice->sound_lengths[j];
+                  }
+              else
+                {
+                  int16_t dx = 0;
+                  while (l >= ax)
+                    {
+                      uint16_t next_pattern_offset;
+                      k = script->icb[stage].stretch;
+                      j = ((uint16_t)(script->sounds[i + 1].id)) & 0xFF;
+                      next_pattern_offset = script->voice->sound_offsets[j + 1];
+                      j = script->voice->sound_offsets[j];
+                      sink_put(consumer, 0);
+                      ax = (int16_t)(script->voice->samples[j]);
+                      do
+                        {
+                          ax -= (int16_t)(script->voice->samples[sidx]);
+                          ax = (int16_t)(((int32_t)ax) * ((int32_t)(dx++)) / ((int32_t)l));
+                          ax += (int16_t)(script->voice->samples[sidx++]);
+                          sink_put(consumer, (int8_t)ax);
+                          ax = ((++j) < next_pattern_offset) ? ((int16_t)(script->voice->samples[j])) : 0;
+                        }
+                      while ((--k) && (--scnt));
+                      if (k)
+                        {
+                          dx += silence(consumer, k);
+                        }
+                      else if (scnt > 1)
+                        {
+                          dx += fading(consumer, script->voice, sidx);
+                        }
+                      ax = dx + eval(&(script->icb[stage]));
+                      j = ((uint16_t)(script->sounds[i].id)) & 0xFF;
+                      sidx = script->voice->sound_offsets[j];
+                      scnt = script->voice->sound_lengths[j];
+                    }
+                  }
                 }
-            }
-        }
+              }
     }
 
   /* Flush output buffer */

--- a/src/soundproducer.c
+++ b/src/soundproducer.c
@@ -197,78 +197,47 @@ void make_sound(soundscript_t *script, sink_t *consumer)
             {
               /* Mixed and transitional sounds */
 
-              if (script->timing_rate_factor >= DECRACKLING_RATE_THRESHOLD)
+              int16_t dx = 0;
+              while (l >= ax)
                 {
-                  int16_t dx = 0;
-                  uint16_t next_j = ((uint16_t)(script->sounds[i + 1].id)) & 0xFF;
-                  uint16_t next_pattern_offset = script->voice->sound_offsets[next_j];
-                  uint16_t current_pattern_end = script->voice->sound_offsets[j] + scnt;
-
-                  while (l >= ax)
+                  uint16_t next_pattern_offset;
+                  k = script->icb[stage].stretch;
+                  j = ((uint16_t)(script->sounds[i + 1].id)) & 0xFF;
+                  next_pattern_offset = script->voice->sound_offsets[j + 1];
+                  j = script->voice->sound_offsets[j];
+                  sink_put(consumer, 0);
+                  ax = (int16_t)(script->voice->samples[j]);
+                  do
                     {
-                      k = script->icb[stage].stretch;
-                      uint16_t samples_to_process = k;
-
-                      do
+                      ax -= (int16_t)(script->voice->samples[sidx]);
+                      ax = (int16_t)(((int32_t)ax) * ((int32_t)(dx++)) / ((int32_t)l));
+                      if (script->timing_rate_factor >= DECRACKLING_RATE_THRESHOLD)
                         {
-                          if (sidx < current_pattern_end)
-                            {
-                              sink_put(consumer, script->voice->samples[sidx++]);
-                            }
-                          l--;
+                          static int32_t filtered = 0;
+                          filtered = filtered * ((ax - filtered));
+                          ax = (int16_t)filtered;
                         }
-                      while ((--k) && (--scnt));
-
-                      if (scnt > 1)
-                        {
-                          l -= fading(consumer, script->voice, sidx);
-                        }
-                      dx += (samples_to_process - k);
-
-                      ax = dx + eval(&(script->icb[stage]));
-                      j = ((uint16_t)(script->sounds[i].id)) & 0xFF;
-                      sidx = script->voice->sound_offsets[j];
-                      scnt = script->voice->sound_lengths[j];
+                      ax += (int16_t)(script->voice->samples[sidx++]);
+                      sink_put(consumer, (int8_t)ax);
+                      ax = ((++j) < next_pattern_offset) ? ((int16_t)(script->voice->samples[j])) : 0;
                     }
-                  }
-              else
-                {
-                  int16_t dx = 0;
-                  while (l >= ax)
+                  while ((--k) && (--scnt));
+                  if (k)
                     {
-                      uint16_t next_pattern_offset;
-                      k = script->icb[stage].stretch;
-                      j = ((uint16_t)(script->sounds[i + 1].id)) & 0xFF;
-                      next_pattern_offset = script->voice->sound_offsets[j + 1];
-                      j = script->voice->sound_offsets[j];
-                      sink_put(consumer, 0);
-                      ax = (int16_t)(script->voice->samples[j]);
-                      do
-                        {
-                          ax -= (int16_t)(script->voice->samples[sidx]);
-                          ax = (int16_t)(((int32_t)ax) * ((int32_t)(dx++)) / ((int32_t)l));
-                          ax += (int16_t)(script->voice->samples[sidx++]);
-                          sink_put(consumer, (int8_t)ax);
-                          ax = ((++j) < next_pattern_offset) ? ((int16_t)(script->voice->samples[j])) : 0;
-                        }
-                      while ((--k) && (--scnt));
-                      if (k)
-                        {
-                          dx += silence(consumer, k);
-                        }
-                      else if (scnt > 1)
-                        {
-                          dx += fading(consumer, script->voice, sidx);
-                        }
-                      ax = dx + eval(&(script->icb[stage]));
-                      j = ((uint16_t)(script->sounds[i].id)) & 0xFF;
-                      sidx = script->voice->sound_offsets[j];
-                      scnt = script->voice->sound_lengths[j];
+                      dx += silence(consumer, k);
                     }
-                  }
+                  else if (scnt > 1)
+                    {
+                      dx += fading(consumer, script->voice, sidx);
+                    }
+                  ax = dx + eval(&(script->icb[stage]));
+                  j = ((uint16_t)(script->sounds[i].id)) & 0xFF;
+                  sidx = script->voice->sound_offsets[j];
+                  scnt = script->voice->sound_lengths[j];
                 }
               }
-    }
+            }
+          }
 
   /* Flush output buffer */
   sink_flush(consumer);

--- a/src/soundproducer.c
+++ b/src/soundproducer.c
@@ -210,11 +210,11 @@ void make_sound(soundscript_t *script, sink_t *consumer)
                   do
                     {
                       ax -= (int16_t)(script->voice->samples[sidx]);
-                      ax = (int16_t)(((int32_t)ax) * ((int32_t)(dx++)) / ((int32_t)l));
+                      ax = (int16_t)(((int32_t)ax * (int32_t)(dx++) + ((rand() & 7) - 2)) / (int32_t)l);
                       if (script->timing_rate_factor >= DECRACKLING_RATE_THRESHOLD)
                         {
                           static int32_t filtered = 0;
-                          filtered = filtered * ((ax - filtered));
+                          filtered = ((ax >> 1));
                           ax = (int16_t)filtered;
                         }
                       ax += (int16_t)(script->voice->samples[sidx++]);

--- a/src/soundscript.h
+++ b/src/soundscript.h
@@ -58,6 +58,7 @@ typedef struct
   size_t length;
   sound_unit_t sounds[MAX_SOUNDS];
   icb_t icb[NSTAGES];
+  uint16_t timing_rate_factor;
 } soundscript_t;
 
 

--- a/src/speechrate_control.c
+++ b/src/speechrate_control.c
@@ -160,7 +160,7 @@ void apply_speechrate(soundscript_t *script, timing_t *timing, time_plan_ptr_t d
 {
   uint16_t i;
   uint8_t n = 1;
-
+  script->timing_rate_factor = timing->rate_factor;
   for (i = 0; i < script->length; i++)
     {
       uint8_t j = script->sounds[i].id;


### PR DESCRIPTION
Introduce a new algorithm to prevent audio crackling at high speech rates.

*by adding a conditional branch when the timing rate factor exceeds

**DECRACKLING_RATE_THRESHOLD.

*For mixed and transitional sounds (j < 132) at high rates, it processes

**samples differently to avoid crackling

However, speech using this algorithm only sounds good at high speeds, so the threshold is set.