### PR TITLE
Refactor/phoneme naming

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,5 +20,6 @@ librutts_la_SOURCES = synth.c sink.c transcription.c text2speech.c \
 	intonator.c soundproducer.c numerics.c male.c female.c
 
 EXTRA_DIST = ru_tts.vscript modulation.h numerics.h soundscript.h \
-	synth.h sink.h timing.h transcription.h voice.h
+	synth.h sink.h timing.h transcription.h voice.h \
+	phonemes.h
 MAINTAINERCLEANFILES = @srcdir@/Makefile.in @srcdir@/config.h.in @srcdir@/config.h.in~

--- a/src/intonator.c
+++ b/src/intonator.c
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "phonemes.h"
 #include "transcription.h"
 #include "soundscript.h"
 #include "modulation.h"
@@ -265,9 +266,9 @@ static int search_breakpoint(uint8_t *transcription, int start_index)
   for (i = start_index; i < TRANSCRIPTION_BUFFER_SIZE; i++)
     {
       rc = transcription[i];
-      if (rc != 43)
+      if (rc != PH_SPACE)
         {
-          if (rc > 43)
+          if (rc > PH_SPACE)
             return -1;
           break;
         }
@@ -275,7 +276,7 @@ static int search_breakpoint(uint8_t *transcription, int start_index)
   for (i++; i < TRANSCRIPTION_BUFFER_SIZE; i++)
     {
       rc = transcription[i];
-      if (rc > 42)
+      if (rc > PH_TERMINATOR)
         return rc;
     }
   return -1;
@@ -338,10 +339,10 @@ void apply_intonation(uint8_t *transcription, soundscript_t *soundscript,
       bp = search_breakpoint(transcription, i);
       if (bp < 0)
         break;
-      if (bp != 54)
+      if (bp != PH_SECONDARY_STRESS)
         nspeechmarks++;
       while (((++i) < TRANSCRIPTION_BUFFER_SIZE) &&
-             ((transcription[i] >= 53) || (transcription[i] < 43)));
+             ((transcription[i] >= PH_PRIMARY_STRESS) || (transcription[i] < PH_SPACE)));
     }
 
   for (i = 0; i < NSTAGES; i++)
@@ -379,19 +380,19 @@ void apply_intonation(uint8_t *transcription, soundscript_t *soundscript,
                   st4 = 1;
                 }
               bp = search_breakpoint(transcription, i);
-              m = ((bp != 53) && (bp != 54)) ? 1 : 2;
+              m = ((bp != PH_PRIMARY_STRESS) && (bp != PH_SECONDARY_STRESS)) ? 1 : 2;
             }
 
           if (m < 3)
             {
-              if ((m < 2) && (transcription[i] > 5))
+              if ((m < 2) && (transcription[i] > PH_I))
                 {
                   j = setstage(soundscript, j, stage);
                   continue;
                 }
-              else if ((m > 1) && ((transcription[i] > 5) || (transcription[i + 1] != 53)))
+              else if ((m > 1) && ((transcription[i] > PH_I) || (transcription[i + 1] != PH_PRIMARY_STRESS)))
                 {
-                  if (transcription[i] != 54)
+                  if (transcription[i] != PH_SECONDARY_STRESS)
                     j = setstage(soundscript, j, stage);
                   continue;
                 }
@@ -415,11 +416,11 @@ void apply_intonation(uint8_t *transcription, soundscript_t *soundscript,
           if (m > 2)
             {
               uint8_t l = transcription[i];
-              if (l < 53)
+              if (l < PH_PRIMARY_STRESS)
                 {
-                  if (l < 43)
+                  if (l < PH_SPACE)
                     j = setstage(soundscript, j, stage + 3);
-                  else if (l != 43)
+                  else if (l != PH_SPACE)
                     break;
                   else
                     {
@@ -427,7 +428,7 @@ void apply_intonation(uint8_t *transcription, soundscript_t *soundscript,
                       bp = search_breakpoint(transcription, i + 1);
                       if (bp < 0)
                         break;
-                      else if (bp != 54)
+                      else if (bp != PH_SECONDARY_STRESS)
                         {
                           nspeechmarks--;
                           m = 0;

--- a/src/numerics.c
+++ b/src/numerics.c
@@ -11,6 +11,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "phonemes.h"
 #include "numerics.h"
 #include "transcription.h"
 #include "sink.h"
@@ -28,91 +29,91 @@
 /* Predefined transcriptions */
 static const uint8_t primary[] = /* 0..9 */
   {
-    4, 16, 1, 53, 17,
-    5, 2, 24, 5, 53, 16,
-    4, 21, 6, 2, 53,
-    4, 27, 13, 5, 53,
-    7, 33, 3, 27, 4, 53, 13, 3,
-    4, 29, 2, 53, 30,
-    5, 36, 3, 53, 38, 30,
-    4, 38, 3, 53, 15,
-    6, 6, 1, 53, 38, 3, 15,
-    6, 24, 3, 53, 11, 2, 30
+    4, PH_N, PH_O, PH_PRIMARY_STRESS, PH_L_,
+    5, PH_A, PH_D_, PH_I, PH_PRIMARY_STRESS, PH_N,
+    4, PH_D, PH_V, PH_A, PH_PRIMARY_STRESS,
+    4, PH_T, PH_R_, PH_I, PH_PRIMARY_STRESS,
+    7, PH_CH, PH_E, PH_T, PH_Y, PH_PRIMARY_STRESS, PH_R_, PH_E,
+    4, PH_P_, PH_A, PH_PRIMARY_STRESS, PH_T_,
+    5, PH_SH, PH_E, PH_PRIMARY_STRESS, PH_S_, PH_T_,
+    4, PH_S_, PH_E, PH_PRIMARY_STRESS, PH_M,
+    6, PH_V, PH_O, PH_PRIMARY_STRESS, PH_S_, PH_E, PH_M,
+    6, PH_D_, PH_E, PH_PRIMARY_STRESS, PH_V_, PH_A, PH_T_
   };
 static const uint8_t secondary[] = /* 10..19 */
   {
-    6, 24, 3, 53, 38, 2, 30,
-    9, 2, 24, 5, 53, 16, 2, 32, 2, 30,
-    9, 21, 11, 3, 16, 2, 53, 32, 2, 30,
-    9, 27, 13, 5, 16, 2, 53, 32, 2, 30,
-    11, 33, 3, 27, 4, 53, 8, 16, 2, 32, 2, 30,
-    9, 29, 2, 27, 16, 2, 53, 32, 2, 30,
-    9, 36, 3, 35, 16, 2, 53, 32, 2, 30,
-    9, 38, 3, 15, 16, 2, 53, 32, 2, 30,
-    11, 6, 2, 38, 3, 15, 16, 2, 53, 32, 2, 30,
-    11, 24, 3, 11, 2, 27, 16, 2, 53, 32, 2, 30
+    6, PH_D_, PH_E, PH_PRIMARY_STRESS, PH_S_, PH_A, PH_T_,
+    9, PH_A, PH_D_, PH_I, PH_PRIMARY_STRESS, PH_N, PH_A, PH_C, PH_A, PH_T_,
+    9, PH_D, PH_V_, PH_E, PH_N, PH_A, PH_PRIMARY_STRESS, PH_C, PH_A, PH_T_,
+    9, PH_T, PH_R_, PH_I, PH_N, PH_A, PH_PRIMARY_STRESS, PH_C, PH_A, PH_T_,
+    11, PH_CH, PH_E, PH_T, PH_Y, PH_PRIMARY_STRESS, PH_R, PH_N, PH_A, PH_C, PH_A, PH_T_,
+    9, PH_P_, PH_A, PH_T, PH_N, PH_A, PH_PRIMARY_STRESS, PH_C, PH_A, PH_T_,
+    9, PH_SH, PH_E, PH_S, PH_N, PH_A, PH_PRIMARY_STRESS, PH_C, PH_A, PH_T_,
+    9, PH_S_, PH_E, PH_M, PH_N, PH_A, PH_PRIMARY_STRESS, PH_C, PH_A, PH_T_,
+    11, PH_V, PH_A, PH_S_, PH_E, PH_M, PH_N, PH_A, PH_PRIMARY_STRESS, PH_C, PH_A, PH_T_,
+    11, PH_D_, PH_E, PH_V_, PH_A, PH_T, PH_N, PH_A, PH_PRIMARY_STRESS, PH_C, PH_A, PH_T_
   };
 static const uint8_t tens[] = /* 20..90 */
   {
-    7, 21, 6, 2, 53, 32, 2, 30,
-    7, 27, 13, 5, 53, 32, 2, 30,
-    6, 35, 1, 53, 8, 2, 28,
-    8, 29, 2, 24, 3, 38, 2, 53, 27,
-    9, 36, 3, 12, 24, 3, 38, 2, 53, 27,
-    9, 38, 3, 53, 15, 24, 3, 38, 2, 27,
-    11, 6, 1, 53, 38, 3, 15, 24, 3, 38, 2, 27,
-    10, 24, 3, 11, 2, 16, 1, 53, 35, 27, 2
+    7, PH_D, PH_V, PH_A, PH_PRIMARY_STRESS, PH_C, PH_A, PH_T_,
+    7, PH_T, PH_R_ , PH_I, PH_PRIMARY_STRESS, PH_C, PH_A, PH_T_,
+    6, PH_S, PH_O, PH_PRIMARY_STRESS, PH_R, PH_A, PH_K,
+    8, PH_P_, PH_A, PH_D_, PH_E, PH_S_, PH_A, PH_PRIMARY_STRESS, PH_T,
+    9, PH_SH, PH_E, PH_Z_, PH_D_, PH_E, PH_S_, PH_A, PH_PRIMARY_STRESS, PH_T,
+    9, PH_S_, PH_E, PH_PRIMARY_STRESS, PH_M, PH_D_, PH_E, PH_S_, PH_A, PH_T,
+    11, PH_V, PH_O, PH_PRIMARY_STRESS, PH_S_, PH_E, PH_M, PH_D_, PH_E, PH_S_, PH_A, PH_T,
+    10, PH_D_, PH_E, PH_V_, PH_A, PH_N, PH_O, PH_PRIMARY_STRESS, PH_S, PH_T, PH_A
   };
 static const uint8_t hundreds[] = /* 100..900 */
   {
-    4, 35, 27, 1, 53,
-    7, 21, 11, 3, 53, 38, 30, 5,
-    7, 27, 13, 5, 53, 35, 27, 2,
-    10, 33, 3, 27, 4, 53, 13, 3, 35, 27, 2,
-    7, 29, 2, 27, 35, 1, 53, 27,
-    7, 36, 3, 35, 35, 1, 53, 27,
-    7, 38, 3, 15, 35, 1, 53, 27,
-    9, 6, 2, 38, 3, 15, 35, 1, 53, 27,
-    9, 24, 3, 11, 2, 27, 35, 1, 53, 27
+    4, PH_S, PH_T, PH_O, PH_PRIMARY_STRESS,
+    7, PH_D, PH_V_, PH_E, PH_PRIMARY_STRESS, PH_S_, PH_T_, PH_I,
+    7, PH_T, PH_R_, PH_I, PH_PRIMARY_STRESS, PH_S, PH_T, PH_A,
+    10, PH_CH, PH_E, PH_T, PH_Y, PH_PRIMARY_STRESS, PH_R_, PH_E, PH_S, PH_T, PH_A,
+    7, PH_P_, PH_A, PH_T, PH_S, PH_O, PH_PRIMARY_STRESS, PH_T,
+    7, PH_SH, PH_E, PH_S, PH_S, PH_O, PH_PRIMARY_STRESS, PH_T,
+    7, PH_S_, PH_E, PH_M, PH_S, PH_O, PH_PRIMARY_STRESS, PH_T,
+    9, PH_V, PH_A, PH_S_, PH_E, PH_M, PH_S, PH_O, PH_PRIMARY_STRESS, PH_T,
+    9, PH_D_, PH_E, PH_V_, PH_A, PH_T, PH_S, PH_O, PH_PRIMARY_STRESS, PH_T
   };
 static const uint8_t periods[] =
   {
-    6, 27, 4, 53, 38, 2, 33,
-    7, 18, 5, 17, 5, 1, 53, 16,
-    8, 18, 5, 17, 5, 2, 53, 8, 27,
-    8, 27, 13, 5, 17, 5, 1, 53, 16
+    6, PH_T, PH_Y, PH_PRIMARY_STRESS, PH_S_, PH_A, PH_CH,
+    7, PH_M_, PH_I, PH_L_, PH_I, PH_O, PH_PRIMARY_STRESS, PH_N,
+    8, PH_M_, PH_I, PH_L_, PH_I, PH_A, PH_PRIMARY_STRESS, PH_R, PH_T,
+    8, PH_T, PH_R_, PH_I, PH_L_, PH_I, PH_O, PH_PRIMARY_STRESS, PH_N
   };
 static const uint8_t fractions[] =
   {
-    6, 24, 3, 38, 2, 53, 27,
-    4, 35, 1, 53, 27,
-    7, 27, 4, 53, 38, 2, 33, 16,
-    13, 24, 3, 38, 2, 30, 5, 27, 4, 53, 38, 2, 33, 16,
-    10, 35, 27, 1, 27, 4, 53, 38, 2, 33, 16,
-    8, 18, 5, 17, 5, 1, 53, 16, 16,
-    14, 24, 3, 38, 2, 30, 5, 18, 5, 17, 5, 1, 53, 16, 16,
-    11, 35, 27, 1, 18, 5, 17, 5, 1, 53, 16, 16,
-    9, 18, 5, 17, 5, 2, 53, 8, 27, 16,
-    15, 24, 3, 38, 2, 30, 5, 18, 5, 17, 5, 2, 53, 8, 27, 16,
-    12, 35, 27, 1, 18, 5, 17, 5, 2, 53, 8, 27, 16,
-    9, 27, 13, 5, 17, 5, 1, 53, 16, 16,
-    15, 24, 3, 38, 2, 30, 5, 27, 13, 5, 17, 5, 1, 53, 16, 16,
-    12, 35, 27, 1, 27, 13, 5, 17, 5, 1, 53, 16, 16
+    6, PH_D_, PH_E, PH_S_, PH_A, PH_PRIMARY_STRESS, PH_T,
+    4, PH_S, PH_O, PH_PRIMARY_STRESS, PH_T,
+    7, PH_T, PH_Y, PH_PRIMARY_STRESS, PH_S_, PH_A, PH_CH, PH_N,
+    13, PH_D_, PH_E, PH_S_, PH_A, PH_T_, PH_I, PH_T, PH_Y, PH_PRIMARY_STRESS, PH_S_, PH_A, PH_CH, PH_N,
+    10, PH_S, PH_T, PH_O, PH_T, PH_Y, PH_PRIMARY_STRESS, PH_S_, PH_A, PH_CH, PH_N,
+    8, PH_M_, PH_I, PH_L_, PH_I, PH_O, PH_PRIMARY_STRESS, PH_N, PH_N,
+    14, PH_D_, PH_E, PH_S_, PH_A, PH_T_, PH_I, PH_M_, PH_I, PH_L_, PH_I, PH_O, PH_PRIMARY_STRESS, PH_N, PH_N,
+    11, PH_S, PH_T, PH_O, PH_M_, PH_I, PH_L_, PH_I, PH_O, PH_PRIMARY_STRESS, PH_N, PH_N,
+    9, PH_M_, PH_I, PH_L_, PH_I, PH_A, PH_PRIMARY_STRESS, PH_R, PH_T, PH_N,
+    15, PH_D_, PH_E, PH_S_, PH_A, PH_T_, PH_I, PH_M_, PH_I, PH_L_, PH_I, PH_A, PH_PRIMARY_STRESS, PH_R, PH_T, PH_N,
+    12, PH_S, PH_T, PH_O, PH_M_, PH_I, PH_L_, PH_I, PH_A, PH_PRIMARY_STRESS, PH_R, PH_T, PH_N,
+    9, PH_T, PH_R_, PH_I, PH_L_, PH_I, PH_O, PH_PRIMARY_STRESS, PH_N, PH_N,
+    15, PH_D_, PH_E, PH_S_, PH_A, PH_T_, PH_I, PH_T, PH_R_, PH_I, PH_L_, PH_I, PH_O, PH_PRIMARY_STRESS, PH_N, PH_N,
+    12, PH_S, PH_T, PH_O, PH_T, PH_R_, PH_I, PH_L_, PH_I, PH_O, PH_PRIMARY_STRESS, PH_N, PH_N
   };
 static const uint8_t suffixes[] =
   {
-    2, 4, 40,
-    3, 2, 10, 2,
-    2, 2, 34
+    2, PH_Y, PH_X,
+    3, PH_A, PH_J, PH_A,
+    2, PH_A, PH_F
   };
 static const uint8_t one_int[] =
   {
-    2, 21, 16, 2, 53, 43,
-    32, 3, 53, 14, 2, 10, 2, 43
+    PH_A, PH_D, PH_N, PH_A, PH_PRIMARY_STRESS, PH_SPACE,
+    PH_C, PH_E, PH_PRIMARY_STRESS, PH_L, PH_A, PH_J, PH_A, PH_SPACE
   };
-static const uint8_t one_o[] = { 2, 21, 16, 1, 53, 43 };
-static const uint8_t two_e[] = { 21, 11, 3, 53, 43 };
-static const uint8_t n_ints[] = { 32, 3, 53, 14, 4, 40 };
+static const uint8_t one_o[] = { PH_A, PH_D, PH_N, PH_O, PH_PRIMARY_STRESS, PH_SPACE };
+static const uint8_t two_e[] = { PH_D, PH_V_, PH_E, PH_PRIMARY_STRESS, PH_SPACE };
+static const uint8_t n_ints[] = { PH_C, PH_E, PH_PRIMARY_STRESS, PH_L, PH_Y, PH_X };
 
 
 /* Local subroutines */
@@ -129,7 +130,7 @@ static void transcribe_digit(sink_t *consumer, char digit, char following)
 {
   put_transcription(consumer, primary, digit - '0');
   if (following != ' ')
-    sink_put(consumer, 43);
+    sink_put(consumer, PH_SPACE);
 }
 
 /* Return true if specified character may be treated as decimal point. */
@@ -159,8 +160,8 @@ void process_number(input_t *input, sink_t *consumer)
       uint8_t n;
 
       flags &= ~NON_ZERO;
-      if (sink_last(consumer) != 43)
-        sink_put(consumer, 43);
+      if (sink_last(consumer) != PH_SPACE)
+        sink_put(consumer, PH_SPACE);
       for (s = input->start + 1; s < input->end; s++)
         if (IS_DIGIT(s[0]))
           {
@@ -196,7 +197,7 @@ void process_number(input_t *input, sink_t *consumer)
                 {
                 case 3:
                   put_transcription(consumer, hundreds, c - '1');
-                  sink_put(consumer, 43);
+                  sink_put(consumer, PH_SPACE);
                   break;
                 case 1:
                   if (c == '1')
@@ -270,7 +271,7 @@ void process_number(input_t *input, sink_t *consumer)
                       digits--;
                     }
                   else put_transcription(consumer, tens, c - '2');
-                  sink_put(consumer, 43);
+                  sink_put(consumer, PH_SPACE);
                   break;
                 }
             }
@@ -304,15 +305,15 @@ void process_number(input_t *input, sink_t *consumer)
                             {
                               if (nc != 1)
                                 {
-                                  if (sink_last(consumer) == 27)
-                                    sink_replace(consumer, 21);
+                                  if (sink_last(consumer) == PH_T)
+                                    sink_replace(consumer, PH_D);
                                   if (nc > 1)
-                                    sink_put(consumer, 2);
+                                    sink_put(consumer, PH_A);
                                   else put_transcription(consumer, suffixes, 2);
                                 }
                             }
                           else if (nc > 0)
-                            sink_put(consumer, (nc > 1) ? 5 : 2);
+                            sink_put(consumer, (nc > 1) ? PH_I : PH_A);
                           sink_flush(consumer);
                         }
                       digits = 3;
@@ -331,7 +332,7 @@ void process_number(input_t *input, sink_t *consumer)
         break;
       else if (flags & NUMBER_FRACTION)
         {
-          sink_put(consumer, 43);
+          sink_put(consumer, PH_SPACE);
           put_transcription(consumer, fractions, n - 1);
           put_transcription(consumer, suffixes, (nc != 1) ? 0 : 1);
           break;
@@ -339,7 +340,7 @@ void process_number(input_t *input, sink_t *consumer)
       else if (((input->start + 1) < input->end) && check_dec_point(consumer, input->start[0]) && IS_DIGIT(input->start[1]))
         {
           flags |= NUMBER_FRACTION;
-          sink_put(consumer, 43);
+          sink_put(consumer, PH_SPACE);
           if (nc != 1)
             {
               sink_write(consumer, n_ints, 6);
@@ -348,7 +349,7 @@ void process_number(input_t *input, sink_t *consumer)
         }
       else
         {
-          sink_put(consumer, 43);
+          sink_put(consumer, PH_SPACE);
           break;
         }
     }

--- a/src/phonemes.h
+++ b/src/phonemes.h
@@ -1,0 +1,73 @@
+/* phonemes.h -- phoncodes
+ *
+ * Copyright (C) 1990, 1991 Speech Research Laboratory, Minsk
+ * Copyright (C) 2005 Igor Poretsky <poretsky@mlbox.ru>
+ * Copyright (C) 2021 Boris Lobanov <lobbormef@gmail.com>
+ * Copyright (C) 2021 Alexander Ivanov <ivalex01@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef RU_TTS_PHONEMES_H
+#define RU_TTS_PHONEMES_H
+
+typedef enum 
+  {
+    PH_U = 0,  /* [у] */
+    PH_O = 1,  /* [о] */
+    PH_A = 2,  /* [а] */
+    PH_E = 3,  /* [э] */
+    PH_Y = 4,  /* [ы] */
+    PH_I = 5,  /* [и] */
+    PH_V = 6,  /* [в] */
+    PH_Z = 7,  /* [з] */
+    PH_R = 8,  /* [р] */
+    PH_ZH = 9,  /* [ж] */
+    PH_J = 10, /* [й] */
+    PH_V_ = 11, /* [в'] */
+    PH_Z_ = 12, /* [з'] */
+    PH_R_ = 13, /* [р'] */
+    PH_L = 14, /* [л] */
+    PH_M = 15, /* [м] */
+    PH_N = 16, /* [н] */
+    PH_L_ = 17, /* [л'] */
+    PH_M_ = 18, /* [м'] */
+    PH_N_ = 19, /* [н'] */
+    PH_B = 20, /* [б] */
+    PH_D = 21, /* [д] */
+    PH_G = 22, /* [г] */
+    PH_B_ = 23, /* [б'] */
+    PH_D_ = 24, /* [д'] */
+    PH_G_ = 25, /* [г'] */
+    PH_P = 26, /* [п] */
+    PH_T = 27, /* [т] */
+    PH_K = 28, /* [к] */
+    PH_P_ = 29, /* [п'] */
+    PH_T_ = 30, /* [т'] */
+    PH_K_ = 31, /* [к'] */
+    PH_C = 32, /* [ц] */
+    PH_CH = 33, /* [ч] */
+    PH_F = 34, /* [ф] */
+    PH_S = 35, /* [с] */
+    PH_SH = 36, /* [ш] */
+    PH_F_ = 37, /* [ф'] */
+    PH_S_ = 38, /* [с'] */
+    PH_SH_ = 39, /* [щ'] */
+    PH_X = 40, /* [х] */
+    PH_X_ = 41, /* [х'] */
+    PH_TERMINATOR = 42, /* '#' */
+    PH_SPACE = 43, /* ' ' */
+    PH_COMMA = 44, /* ',' */
+    PH_PERIOD = 45, /* '.' */
+    PH_SEMICOLON = 46, /* ';' */
+    PH_COLON = 47, /* ':' */
+    PH_QUESTION = 48, /* '?' */
+    PH_EXCLAMATION = 49, /* '!' */
+    PH_OPEN_BRACKET = 50, /* '(' */
+    PH_CLOSE_BRACKET = 51, /* ')' */
+    PH_MINUS = 52, /* '-' */
+    PH_PRIMARY_STRESS = 53, /* '+' */
+    PH_SECONDARY_STRESS = 54  /* '=' */
+  } Phoneme;
+
+#endif 

--- a/src/synth.c
+++ b/src/synth.c
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "phonemes.h"
 #include "synth.h"
 #include "soundscript.h"
 #include "transcription.h"
@@ -22,130 +23,130 @@
 
 static const uint8_t seqlist1[] =
   {
-    1, 2,
-    5, 6, 8, 1, 24, 3,
-    4, 21, 2, 25, 3,
-    2, 21, 2,
-    5, 10, 3, 21, 6, 2,
-    5, 10, 3, 35, 17, 5,
-    3, 5, 17, 5,
-    4, 5, 27, 2, 28,
-    5, 5, 16, 2, 33, 3,
-    1, 5,
-    3, 28, 2, 28,
-    4, 17, 5, 20, 1,
-    2, 16, 1,
-    3, 8, 2, 35,
-    5, 27, 2, 28, 25, 3,
-    3, 27, 2, 28,
-    3, 30, 3, 15,
-    4, 27, 1, 25, 3,
-    3, 40, 1, 30,
-    3, 33, 3, 15,
-    5, 33, 27, 1, 20, 4,
-    4, 33, 27, 1, 26,
-    3, 33, 27, 1,
-    4, 5, 27, 2, 22,
-    3, 28, 2, 22,
-    3, 8, 2, 7,
-    3, 27, 2, 22,
-    3, 40, 1, 24,
-    4, 33, 27, 1, 20,
-    2, 27, 1,
+    1, PH_A,
+    5, PH_V, PH_R, PH_O, PH_D_, PH_E,
+    4, PH_D, PH_A, PH_G_, PH_E,
+    2, PH_D, PH_A,
+    5, PH_J, PH_E, PH_D, PH_V, PH_A,
+    5, PH_J, PH_E, PH_S, PH_L_, PH_I,
+    3, PH_I, PH_L_, PH_I,
+    4, PH_I, PH_T, PH_A, PH_K,
+    5, PH_I, PH_N, PH_A, PH_CH, PH_E,
+    1, PH_I,
+    3, PH_K, PH_A, PH_K,
+    4, PH_L_, PH_I, PH_B, PH_O,
+    2, PH_N, PH_O,
+    3, PH_R, PH_A, PH_S,
+    5, PH_T, PH_A, PH_K, PH_G_, PH_E,
+    3, PH_T, PH_A, PH_K,
+    3, PH_T_, PH_E, PH_M,
+    4, PH_T, PH_O, PH_G_, PH_E,
+    3, PH_X, PH_O, PH_T_,
+    3, PH_CH, PH_E, PH_M,
+    5, PH_CH, PH_T, PH_O, PH_B, PH_Y,
+    4, PH_CH, PH_T, PH_O, PH_P,
+    3, PH_CH, PH_T, PH_O,
+    4, PH_I, PH_T, PH_A, PH_G,
+    3, PH_K, PH_A, PH_G,
+    3, PH_R, PH_A, PH_Z,
+    3, PH_T, PH_A, PH_G,
+    3, PH_X, PH_O, PH_D_,
+    4, PH_CH, PH_T, PH_O, PH_B,
+    2, PH_T, PH_O,
     0
   };
 
 static const uint8_t seqlist2[] =
   {
-    3, 23, 3, 35,
-    3, 23, 3, 7,
-    4, 6, 21, 1, 17,
-    4, 20, 17, 5, 35,
-    4, 20, 17, 5, 7,
-    5, 6, 8, 1, 24, 3,
-    5, 6, 1, 7, 17, 3,
-    5, 6, 11, 5, 21, 0,
-    3, 6, 19, 3,
-    2, 6, 1,
-    1, 6,
-    1, 34,
-    3, 21, 17, 2,
-    2, 21, 1,
-    2, 5, 35,
-    2, 5, 7,
-    2, 28, 1,
-    1, 28,
-    1, 22,
-    5, 18, 3, 9, 21, 0,
-    3, 16, 2, 21,
-    3, 16, 2, 27,
-    2, 16, 2,
-    2, 19, 3,
-    2, 1, 27,
-    2, 1, 21,
-    2, 1, 20,
-    2, 1, 26,
-    1, 1,
-    5, 29, 3, 13, 3, 21,
-    5, 29, 3, 13, 3, 27,
-    5, 26, 1, 35, 17, 3,
-    3, 26, 1, 21,
-    3, 26, 1, 27,
-    3, 26, 13, 5,
-    3, 26, 8, 1,
-    2, 26, 1,
-    4, 8, 2, 24, 5,
-    5, 35, 28, 6, 1, 38,
-    5, 35, 28, 6, 1, 12,
-    6, 35, 11, 3, 8, 40, 2,
-    2, 35, 1,
-    1, 35,
-    5, 7, 7, 2, 24, 5,
-    1, 0,
-    5, 33, 3, 13, 3, 35,
-    5, 33, 3, 13, 3, 7,
-    2, 7, 2,
-    1, 7,
+    3, PH_B_, PH_E, PH_S,
+    3, PH_B_, PH_E, PH_Z,
+    4, PH_V, PH_D, PH_O, PH_L_,
+    4, PH_B, PH_L_, PH_I, PH_S,
+    4, PH_B, PH_L_, PH_I, PH_Z,
+    5, PH_V, PH_R, PH_O, PH_D_, PH_E,
+    5, PH_V, PH_O, PH_Z, PH_L_, PH_E,
+    5, PH_V, PH_V_, PH_I, PH_D, PH_U,
+    3, PH_V, PH_N_, PH_E,
+    2, PH_V, PH_O,
+    1, PH_V,
+    1, PH_F,
+    3, PH_D, PH_L_, PH_A,
+    2, PH_D, PH_O,
+    2, PH_I, PH_S,
+    2, PH_I, PH_Z,
+    2, PH_K, PH_O,
+    1, PH_K,
+    1, PH_G,
+    5, PH_M_, PH_E, PH_ZH, PH_D, PH_U,
+    3, PH_N, PH_A, PH_D,
+    3, PH_N, PH_A, PH_T,
+    2, PH_N, PH_A,
+    2, PH_N_, PH_E,
+    2, PH_O, PH_T,
+    2, PH_O, PH_D,
+    2, PH_O, PH_B,
+    2, PH_O, PH_P,
+    1, PH_O,
+    5, PH_P_, PH_E, PH_R_, PH_E, PH_D,
+    5, PH_P_, PH_E, PH_R_, PH_E, PH_T,
+    5, PH_P, PH_O, PH_S, PH_L_, PH_E,
+    3, PH_P, PH_O, PH_D,
+    3, PH_P, PH_O, PH_T,
+    3, PH_P, PH_R_, PH_I,
+    3, PH_P, PH_R, PH_O,
+    2, PH_P, PH_O,
+    4, PH_R, PH_A, PH_D_, PH_I,
+    5, PH_S, PH_K, PH_V, PH_O, PH_S_,
+    5, PH_S, PH_K, PH_V, PH_O, PH_Z_,
+    6, PH_S, PH_V_, PH_E, PH_R, PH_X, PH_A,
+    2, PH_S, PH_O,
+    1, PH_S,
+    5, PH_Z, PH_Z, PH_A, PH_D_, PH_I,
+    1, PH_U,
+    5, PH_CH, PH_E, PH_R_, PH_E, PH_S,
+    5, PH_CH, PH_E, PH_R_, PH_E, PH_Z,
+    2, PH_Z, PH_A,
+    1, PH_Z,
     0
   };
 
 static const uint8_t seqlist3[] =
   {
-    2, 20, 4,
-    1, 20,
-    2, 9, 3,
-    1, 9,
-    5, 19, 5, 20, 0, 24,
-    1, 26,
-    2, 27, 1,
+    2, PH_B, PH_Y,
+    1, PH_B,
+    2, PH_ZH, PH_E,
+    1, PH_ZH,
+    5, PH_N_, PH_I, PH_B, PH_U, PH_D_,
+    1, PH_P,
+    2, PH_T, PH_O,
     0
   };
 
 static const uint8_t seqlist4[] =
   {
-    3, 2, 6, 2,
-    3, 3, 6, 2,
-    3, 2, 15, 0,
-    3, 3, 15, 0,
-    3, 5, 18, 5,
-    3, 2, 10, 3,
-    3, 2, 10, 2,
-    3, 5, 10, 3,
-    3, 0, 10, 0,
-    4, 1, 53, 6, 2,
-    4, 3, 6, 1, 53,
+    3, PH_A, PH_V, PH_A,
+    3, PH_E, PH_V, PH_A,
+    3, PH_A, PH_M, PH_U,
+    3, PH_E, PH_M, PH_U,
+    3, PH_I, PH_M_, PH_I,
+    3, PH_A, PH_J, PH_E,
+    3, PH_A, PH_J, PH_A,
+    3, PH_I, PH_J, PH_E,
+    3, PH_U, PH_J, PH_U,
+    4, PH_O, PH_PRIMARY_STRESS, PH_V, PH_A,
+    4, PH_E, PH_V, PH_O, PH_PRIMARY_STRESS,
     0
   };
 
 static const uint8_t seqlist5[] =
   {
-    2, 5, 10,
-    3, 1, 53, 10,
-    2, 3, 10,
-    2, 5, 40,
-    2, 5, 15,
-    3, 1, 53, 15,
-    2, 3, 15,
+    2, PH_I, PH_J,
+    3, PH_O, PH_PRIMARY_STRESS, PH_J,
+    2, PH_E, PH_J,
+    2, PH_I, PH_X,
+    2, PH_I, PH_M,
+    3, PH_O, PH_PRIMARY_STRESS, PH_M,
+    2, PH_E, PH_M,
     0
   };
 
@@ -160,7 +161,7 @@ static int test_list(const uint8_t *ptr, const uint8_t *lst)
 {
   const uint8_t *item;
   for (item = lst; item[0] && memcmp(ptr, item + 1, item[0]); item += item[0] + 1);
-  return (item[0] != 0) && (ptr[item[0]] > 42) && (ptr[item[0]] < 53);
+  return (item[0] != 0) && (ptr[item[0]] > PH_TERMINATOR) && (ptr[item[0]] < PH_PRIMARY_STRESS);
 }
 
 /* Shift clause transcription one point left */
@@ -172,8 +173,8 @@ static void shift(uint8_t *buf)
       buf[i] = buf[i + 1];
       i++;
     }
-  while ((buf[i] < 44) || (buf[i] > 52));
-  buf[i] = 43;
+  while ((buf[i] < PH_COMMA) || (buf[i] > PH_MINUS));
+  buf[i] = PH_SPACE;
 }
 
 /*
@@ -187,7 +188,7 @@ static uint8_t *transcription_advance(uint8_t *transcription, uint8_t *point)
       size_t length = (point < (transcription + TRANSCRIPTION_BUFFER_SIZE)) ? (transcription + TRANSCRIPTION_BUFFER_SIZE - point) : 0;
       if (length)
         memmove(transcription + TRANSCRIPTION_START, point, length);
-      memset(transcription + TRANSCRIPTION_START + length, 43, TRANSCRIPTION_BUFFER_SIZE - TRANSCRIPTION_START - length);
+      memset(transcription + TRANSCRIPTION_START + length, PH_SPACE, TRANSCRIPTION_BUFFER_SIZE - TRANSCRIPTION_START - length);
     }
   return transcription + TRANSCRIPTION_START;
 }
@@ -231,7 +232,7 @@ static void synth(uint8_t *transcription, ttscb_t *ttscb)
             {
               if (flags & 1)
                 {
-                  *sptr = 50;
+                  *sptr = PH_OPEN_BRACKET;
                   synth_clause(transcription, ttscb, 0);
                   tptr = transcription_advance(transcription, tptr);
                   count = 0;
@@ -248,7 +249,7 @@ static void synth(uint8_t *transcription, ttscb_t *ttscb)
             }
           else if (test_list(tptr, seqlist3) &&
                    (tptr > (transcription + TRANSCRIPTION_START)) &&
-                   (*(tptr - 1) == 43))
+                   (*(tptr - 1) == PH_SPACE))
             {
               sptr = --tptr;
               shift(sptr);
@@ -256,9 +257,9 @@ static void synth(uint8_t *transcription, ttscb_t *ttscb)
               continue;
             }
         }
-      if (*tptr != 43)
+      if (*tptr != PH_SPACE)
         {
-          if ((*tptr > 43) && (*tptr < 53))
+          if ((*tptr > PH_SPACE) && (*tptr < PH_PRIMARY_STRESS))
             {
               synth_clause(transcription, ttscb, ttscb->transcription_state.clause_type);
               break;
@@ -281,16 +282,16 @@ static void synth(uint8_t *transcription, ttscb_t *ttscb)
           uint8_t k;
           if ((!test_list(tptr - 3, seqlist4)) && (!test_list(tptr - 2, seqlist5)))
             sptr = tptr;
-          next = memchr(tptr + 1, 43, perspective);
+          next = memchr(tptr + 1, PH_SPACE, perspective);
           if (next)
             perspective = (++next) - tptr;
           else next = tptr + perspective + 1;
           for (k = 1; k <= perspective; k++)
-            if ((tptr[k] > 43) && (tptr[k] < 53))
+            if ((tptr[k] > PH_SPACE) && (tptr[k] < PH_PRIMARY_STRESS))
               break;
           if ((k > perspective) && !test_list(next, seqlist1))
             {
-              *sptr = 50;
+              *sptr = PH_OPEN_BRACKET;
               synth_clause(transcription, ttscb, 0);
               tptr = transcription_advance(transcription, sptr + 1) - 1;
               count = 0;

--- a/src/time_planner.c
+++ b/src/time_planner.c
@@ -12,8 +12,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "phonemes.h"
 #include "soundscript.h"
 #include "transcription.h"
+
 
 
 /* Local macros */
@@ -37,17 +39,17 @@ typedef struct
 /* Static data */
 
 /* Phoncode sets for classification */
-static const uint8_t set0[] = { 44, 45, 48, 49, 46, 47, 50, 51 };
-static const uint8_t set1[] = { 10, 15, 18, 16, 19, 8, 13, 14, 17 };
-static const uint8_t set2[] = { 6, 11, 7, 12, 9 };
-static const uint8_t set3[] = { 20, 23, 21, 24, 22, 25 };
-static const uint8_t set4[] = { 34, 37, 35, 38, 32, 36, 39, 33, 40, 41 };
-static const uint8_t set5[] = { 26, 29, 27, 30, 28, 31 };
-static const uint8_t set6[] = { 10, 14, 17, 15, 18, 16, 19, 8, 13 };
-static const uint8_t set7[] = { 6, 11, 7, 12, 9, 20, 23, 21, 24, 22, 25 };
-static const uint8_t set8[] = { 20, 23, 26, 29, 15, 18, 6, 11, 34, 37 };
-static const uint8_t set9[] = { 21, 24, 27, 30, 14, 17, 16, 19, 7, 12, 35, 38, 36, 39, 32, 33, 9 };
-static const uint8_t set10[] = { 22, 25, 28, 31, 40, 41 };
+static const uint8_t set0[] = { PH_COMMA, PH_PERIOD, PH_QUESTION, PH_EXCLAMATION, PH_SEMICOLON, PH_COLON, PH_OPEN_BRACKET, PH_CLOSE_BRACKET };
+static const uint8_t set1[] = { PH_J, PH_M, PH_M_, PH_N, PH_N_, PH_R, PH_R_, PH_L, PH_L_ };
+static const uint8_t set2[] = { PH_V, PH_V_, PH_Z, PH_Z_, PH_ZH };
+static const uint8_t set3[] = { PH_B, PH_B_, PH_D, PH_D_, PH_G, PH_G_ };
+static const uint8_t set4[] = { PH_F, PH_F_, PH_S, PH_S_, PH_C, PH_SH, PH_SH_, PH_CH, PH_X, PH_X_ };
+static const uint8_t set5[] = { PH_P, PH_P_, PH_T, PH_T_, PH_K, PH_K_ };
+static const uint8_t set6[] = { PH_J, PH_L, PH_L_, PH_M, PH_M_, PH_N, PH_N_, PH_R, PH_R_ };
+static const uint8_t set7[] = { PH_V, PH_V_, PH_Z, PH_Z_, PH_ZH, PH_B, PH_B_, PH_D, PH_D_, PH_G, PH_G_ };
+static const uint8_t set8[] = { PH_B, PH_B_, PH_P, PH_P_, PH_M, PH_M_, PH_V, PH_V_, PH_F, PH_F_ };
+static const uint8_t set9[] = { PH_D, PH_D_, PH_T, PH_T_, PH_L, PH_L_, PH_N, PH_N_, PH_Z, PH_Z_, PH_S, PH_S_, PH_SH, PH_SH_, PH_C, PH_CH, PH_ZH };
+static const uint8_t set10[] = { PH_G, PH_G_, PH_K, PH_K_, PH_X, PH_X_ };
 
 
 /* Local subroutines */
@@ -113,9 +115,9 @@ time_plan_ptr_t plan_time(uint8_t *transcription)
   memset(scratch, 0, sizeof(workspace_t));
 
   for (i = TRANSCRIPTION_START; i < TRANSCRIPTION_BUFFER_SIZE; i++)
-    if (transcription[i] > 5)
+    if (transcription[i] > PH_I)
       {
-        if (transcription[i] != 43)
+        if (transcription[i] != PH_SPACE)
           {
             uint8_t *found = memchr(set0, transcription[i], sizeof(set0));
 
@@ -211,13 +213,13 @@ time_plan_ptr_t plan_time(uint8_t *transcription)
                                 while (1)
                                   {
                                     phoncode_cur = transcription[++i];
-                                    if ((phoncode_cur < 6) || memchr(set6, phoncode_cur, sizeof(set6)))
+                                    if ((phoncode_cur < PH_V) || memchr(set6, phoncode_cur, sizeof(set6)))
                                       setcase = 2;
                                     else if (memchr(set7, phoncode_cur, sizeof(set7)))
                                       setcase = 3;
-                                    else if ((phoncode_cur > 25) && (phoncode_cur < 42))
+                                    else if ((phoncode_cur > PH_G_) && (phoncode_cur < PH_TERMINATOR))
                                       setcase = 4;
-                                    else if ((phoncode_cur > 43) && (phoncode_cur < 52))
+                                    else if ((phoncode_cur > PH_SPACE) && (phoncode_cur < PH_MINUS))
                                       {
                                         i = TRANSCRIPTION_START;
                                         restart = 1;
@@ -243,8 +245,8 @@ time_plan_ptr_t plan_time(uint8_t *transcription)
                                 values[5] = scratch->area[1][scratch->ndx2];
                                 for (k = 2; k < TIME_PLAN_ROWS; k++)
                                   draft[k][m] = values[k] ? (values[k] - 1) : 0;
-                                if ((phoncode_prev > 5) &&
-                                    (phoncode_prev < 43) &&
+                                if ((phoncode_prev > PH_I) &&
+                                    (phoncode_prev < PH_SPACE) &&
                                     (phoncode_prev == phoncode_cur))
                                   draft[1][m] = 5;
                                 else if ((memchr(set8, phoncode_prev, 4) && memchr(set8, phoncode_cur, sizeof(set8))) ||
@@ -267,7 +269,7 @@ time_plan_ptr_t plan_time(uint8_t *transcription)
                 scratch->flag = 1;
                 if (check_prev)
                   {
-                    if (transcription[i - 1] != 43)
+                    if (transcription[i - 1] != PH_SPACE)
                       {
                         uint8_t rank_prev;
                         uint8_t rank_cur;
@@ -300,9 +302,9 @@ time_plan_ptr_t plan_time(uint8_t *transcription)
         scratch->delta++;
         scratch->flag = 0;
         scratch->area[2][scratch->ndx1 + 1] = scratch->delta;
-        if (transcription[i + 1] != 53)
+        if (transcription[i + 1] != PH_PRIMARY_STRESS)
           {
-            if (transcription[i + 1] != 54)
+            if (transcription[i + 1] != PH_SECONDARY_STRESS)
               scratch->area[0][scratch->ndx1 + 1] = 0;
             else
               {

--- a/src/transcription.c
+++ b/src/transcription.c
@@ -15,6 +15,7 @@
 #include "transcription.h"
 #include "numerics.h"
 #include "sink.h"
+#include "phonemes.h"
 
 
 /* Internal flags */
@@ -54,77 +55,81 @@ static const char *ndts = "NDTS";
 static const char *bgdjz = "BGD_Z";
 
 /* Phoncodes */
-static const uint8_t vocal_phoncodes[] = { 0, 3, 4, 1, 2 };
-static const uint8_t ndts_soft_phs[] = { 19, 24, 30, 38 };
+static const uint8_t vocal_phoncodes[] = { PH_U, PH_E, PH_Y, PH_O, PH_A };
+static const uint8_t ndts_soft_phs[] = { PH_N_, PH_D_, PH_T_, PH_S_ };
 static const uint8_t hard_consonant_phs[] =
   {
-    10, 15, 16, 8,  14, 33, 40, 32, 39,
-    36, 35, 26, 34, 27, 28,
-    9,  7,  20, 6,  21, 22
+    PH_J, PH_M, PH_N, PH_R,  PH_L, PH_CH, PH_X, PH_C, PH_SH_,
+    PH_SH, PH_S , PH_P, PH_F, PH_T, PH_K ,
+    PH_ZH,  PH_Z,  PH_B, PH_V,  PH_D, PH_G
   };
 static const uint8_t soft_consonant_phs[] =
   {
-    10, 18, 19, 13, 17, 33, 41, 32, 39,
-    36, 38, 29, 37, 30, 31,
-    9,  12, 23, 11, 24, 25
+    PH_J, PH_M_, PH_N_, PH_R_, PH_L_, PH_CH, PH_X_, PH_C, PH_SH_,
+    PH_SH, PH_S_, PH_P_, PH_F_, PH_T_, PH_K_,
+    PH_ZH,  PH_Z_, PH_B_, PH_V_, PH_D_, PH_G_
   };
 
 /* Predefined transcription blocks */
 static const uint8_t transcription_blocks[] =
   {
-    3, 27, 3, 53,
-    3, 3, 53, 16,
-    3, 3, 53, 8,
-    3, 3, 53, 17,
-    3, 3, 53, 15,
-    3, 21, 3, 53,
-    3, 26, 3, 53,
-    3, 7, 3, 53,
-    3, 22, 3, 53,
-    3, 33, 3, 53,
-    10, 5, 28, 8, 2, 53, 27, 28, 2, 10, 3,
-    3, 40, 2, 53,
-    3, 9, 3, 53,
-    3, 36, 2, 53,
-    3, 32, 3, 53,
-    3, 39, 2, 53,
-    3, 3, 53, 34,
-    2, 1, 53,
-    3, 10, 3, 53,
-    3, 10, 1, 53,
-    2, 0, 53,
-    3, 10, 2, 53,
-    2, 4, 53,
-    13, 18, 2, 53, 40, 28, 5, 10, 43, 7, 16, 2, 53, 28,
-    14, 27, 11, 1, 53, 8, 21, 4, 10, 43, 7, 16, 2, 53, 28,
-    3, 10, 0, 53,
-    2, 3, 53,
-    8, 28, 2, 6, 4, 53, 33, 31, 5,
+    3, PH_T, PH_E, PH_PRIMARY_STRESS,
+    3, PH_E, PH_PRIMARY_STRESS, PH_N,
+    3, PH_E, PH_PRIMARY_STRESS, PH_R,
+    3, PH_E, PH_PRIMARY_STRESS, PH_L_,
+    3, PH_E, PH_PRIMARY_STRESS, PH_M,
+    3, PH_D, PH_E, PH_PRIMARY_STRESS,
+    3, PH_P, PH_E, PH_PRIMARY_STRESS,
+    3, PH_Z, PH_E, PH_PRIMARY_STRESS,
+    3, PH_G, PH_E, PH_PRIMARY_STRESS,
+    3, PH_CH, PH_E, PH_PRIMARY_STRESS,
+    10, PH_I, PH_K, PH_R, PH_A, PH_PRIMARY_STRESS, PH_T, PH_K, PH_A, PH_J, PH_E,
+    3, PH_X, PH_A, PH_PRIMARY_STRESS,
+    3, PH_ZH, PH_E, PH_PRIMARY_STRESS,
+    3, PH_SH, PH_A, PH_PRIMARY_STRESS,
+    3, PH_C, PH_E, PH_PRIMARY_STRESS,
+    3, PH_SH_, PH_A, PH_PRIMARY_STRESS,
+    3, PH_E, PH_PRIMARY_STRESS, PH_F,
+    2, PH_O , PH_PRIMARY_STRESS,
+    3, PH_J, PH_E , PH_PRIMARY_STRESS,
+    3, PH_J, PH_O , PH_PRIMARY_STRESS,
+    2, PH_U, PH_PRIMARY_STRESS,
+    3, PH_J, PH_A, PH_PRIMARY_STRESS,
+    2, PH_Y, PH_PRIMARY_STRESS,
+    13, PH_M_, PH_A, PH_PRIMARY_STRESS, PH_X_, PH_K , PH_I, PH_J,
+        PH_SPACE, PH_Z, PH_N, PH_A, PH_PRIMARY_STRESS, PH_K,
+    14, PH_T, PH_V_, PH_O, PH_PRIMARY_STRESS, PH_R, PH_D, PH_Y, PH_J,
+        PH_SPACE, PH_Z, PH_N, PH_A, PH_PRIMARY_STRESS, PH_K,
+    3, PH_J, PH_U, PH_PRIMARY_STRESS,
+    2, PH_E, PH_PRIMARY_STRESS,
+    8, PH_K, PH_A, PH_V, PH_Y, PH_PRIMARY_STRESS, PH_CH, PH_K_, PH_I,
     0,
-    8, 0, 15, 16, 1, 53, 9, 5, 30,
-    15, 2, 27, 28, 8, 4, 53, 30, 43, 35, 28, 1, 53, 26, 28, 0,
-    15, 7, 2, 28, 8, 4, 53, 30, 43, 35, 28, 1, 53, 26, 28, 0,
-    10, 26, 8, 2, 32, 3, 53, 16, 27, 2, 34,
-    8, 28, 2, 6, 4, 53, 33, 31, 5,
-    5, 21, 8, 1, 53, 23,
-    10, 2, 15, 26, 3, 8, 35, 3, 53, 16, 21,
-    8, 21, 1, 53, 14, 2, 8, 2, 34,
-    6, 20, 1, 53, 17, 36, 3,
-    6, 18, 3, 53, 19, 36, 3,
-    9, 26, 2, 8, 2, 53, 22, 8, 2, 34,
-    5, 29, 17, 0, 53, 35,
-    11, 8, 2, 6, 19, 2, 53, 10, 3, 27, 38, 2,
+    8, PH_U, PH_M, PH_N, PH_O, PH_PRIMARY_STRESS, PH_ZH, PH_I, PH_T_,
+    15, PH_A, PH_T, PH_K, PH_R, PH_Y, PH_PRIMARY_STRESS, PH_T_,
+        PH_SPACE, PH_S, PH_K, PH_O, PH_PRIMARY_STRESS, PH_P, PH_K, PH_U,
+    15, PH_Z, PH_A, PH_K, PH_R, PH_Y, PH_PRIMARY_STRESS, PH_T_,
+        PH_SPACE, PH_S, PH_K, PH_O, PH_PRIMARY_STRESS, PH_P, PH_K, PH_U,
+    10, PH_P, PH_R, PH_A, PH_C, PH_E, PH_PRIMARY_STRESS, PH_N, PH_T, PH_A, PH_F,
+    8, PH_K, PH_A, PH_V, PH_Y, PH_PRIMARY_STRESS, PH_CH, PH_K_, PH_I,
+    5, PH_D, PH_R, PH_O, PH_PRIMARY_STRESS, PH_B_,
+    10, PH_A, PH_M, PH_P, PH_E, PH_R, PH_S, PH_E, PH_PRIMARY_STRESS, PH_N, PH_D,
+    8, PH_D, PH_O, PH_PRIMARY_STRESS, PH_L, PH_A, PH_R, PH_A, PH_F,
+    6, PH_B, PH_O , PH_PRIMARY_STRESS, PH_L_, PH_SH , PH_E,
+    6, PH_M_, PH_E, PH_PRIMARY_STRESS, PH_N_, PH_SH , PH_E,
+    9, PH_P, PH_A, PH_R, PH_A, PH_PRIMARY_STRESS, PH_G, PH_R, PH_A, PH_F,
+    5, PH_P_, PH_L_, PH_U, PH_PRIMARY_STRESS, PH_S,
+    11, PH_R, PH_A, PH_V, PH_N_, PH_A, PH_PRIMARY_STRESS, PH_J, PH_E, PH_T, PH_S_, PH_A,
 
-    4, 1, 53, 6, 2, /* 42: O+GO */
-    4, 2, 6, 1, 53, /* 43: OGO+ */
-    3, 2, 6, 2, /* 44: OGO */
-    4, 3, 53, 6, 2, /* 45: E+GO (1) */
-    4, 3, 6, 1, 53, /* 46: EGO+ (1) */
-    3, 3, 6, 2, /* 47: EGO (1) */
-    5, 10, 3, 53, 6, 2, /* 48: E+GO (2) */
-    5, 10, 3, 6, 1, 53, /* 49: EGO+ (2) */
-    4, 10, 3, 6, 2, /* 50: EGO (2) */
-    3, 27, 35, 2 /* 51: TSA */
+    4, PH_O, PH_PRIMARY_STRESS, PH_V, PH_A , /* 42: O+GO */
+    4, PH_A , PH_V, PH_O, PH_PRIMARY_STRESS, /* 43: OGO+ */
+    3, PH_A, PH_V, PH_A, /* 44: OGO */
+    4, PH_E, PH_PRIMARY_STRESS, PH_V, PH_A, /* 45: E+GO (1) */
+    4, PH_E, PH_V, PH_O, PH_PRIMARY_STRESS, /* 46: EGO+ (1) */
+    3, PH_E, PH_V, PH_A, /* 47: EGO (1) */
+    5, PH_J, PH_E, PH_PRIMARY_STRESS, PH_V, PH_A, /* 48: E+GO (2) */
+    5, PH_J, PH_E, PH_V, PH_O, PH_PRIMARY_STRESS, /* 49: EGO+ (2) */
+    4, PH_J, PH_E, PH_V, PH_A, /* 50: EGO (2) */
+    3, PH_T, PH_S, PH_A /* 51: TSA */
   };
 
 /* Clause termination pairs */
@@ -161,7 +166,7 @@ static void put_transcription_block(sink_t *consumer, uint8_t n)
   for (i = 1; i <= block[0]; i++)
     {
       uint8_t c = block[i];
-      sink_put(consumer, ((c == 53) && (transcription->flags & WEAK_STRESS)) ? 54 : c);
+      sink_put(consumer, ((c == PH_PRIMARY_STRESS) && (transcription->flags & WEAK_STRESS)) ? PH_SECONDARY_STRESS : c);
     }
 }
 
@@ -215,7 +220,7 @@ static int check_clause_termination(input_t *input, sink_t *consumer)
       for (i = 0; (i < (sizeof(clause_terminations) / sizeof(uint16_t))) && (clause_terminations[i] != termination); i++);
       transcription->clause_type = i & 0x0F;
       transcription->flags |= CLAUSE_DONE;
-      sink_put(consumer, s - symbols + 43);
+      sink_put(consumer, s - symbols + PH_SPACE);
       sink_flush(consumer);
       result = 1;
     }
@@ -229,7 +234,7 @@ static int check_clause_termination(input_t *input, sink_t *consumer)
  */
 static uint8_t voicify(const uint8_t *phs, uint8_t idx)
 {
-  return phs[(idx < 15) ? (idx + 6) : idx];
+  return phs[(idx < PH_M) ? (idx + 6) : idx];
 }
 
 /*
@@ -238,7 +243,7 @@ static uint8_t voicify(const uint8_t *phs, uint8_t idx)
  */
 static uint8_t unvoicify(const uint8_t *phs, uint8_t idx)
 {
-  return phs[(idx < 15) ? idx : (idx - 6)];
+  return phs[(idx < PH_M) ? idx : (idx - 6)];
 }
 
 /*
@@ -248,8 +253,8 @@ static uint8_t unvoicify(const uint8_t *phs, uint8_t idx)
  */
 static uint8_t unvoicify_hard(uint8_t idx, char following)
 {
-  return (((idx != 10) && (idx != 16)) || (following != 'W')) ?
-    unvoicify(hard_consonant_phs, idx) : 36;
+  return (((idx != PH_J) && (idx != PH_N)) || (following != 'W')) ?
+    unvoicify(hard_consonant_phs, idx) : PH_SH;
 }
 
 /*
@@ -261,17 +266,17 @@ static uint8_t correct_consonant(uint8_t idx, char following)
   if (memchr(consonants + 5, following, 10))
     return unvoicify_hard(idx, following);
   else if (strchr(bgdjz, following))
-    return (((idx != 10) && (idx != 16)) || (following != '_')) ?
-      voicify(hard_consonant_phs, idx) : 9;
-  return ((idx != 16) || (following != '_')) ?
-    hard_consonant_phs[idx] : 9;
+    return (((idx != PH_J) && (idx != PH_N)) || (following != '_')) ?
+      voicify(hard_consonant_phs, idx) : PH_ZH;
+  return ((idx != PH_N) || (following != '_')) ?
+    hard_consonant_phs[idx] : PH_ZH;
 }
 
 /* Transcription cycle initialization actions */
 static void transcription_init(sink_t *consumer)
 {
   uint8_t *buffer = consumer->buffer;
-  memset(buffer, 43, TRANSCRIPTION_BUFFER_SIZE);
+  memset(buffer, PH_SPACE, TRANSCRIPTION_BUFFER_SIZE);
   consumer->buffer_offset = TRANSCRIPTION_START;
 }
 
@@ -408,7 +413,7 @@ void process_text(const char *text, sink_t *consumer)
           if (s)
             {
               uint8_t char_index = s - char_list;
-              if ((char_index < 17) &&
+              if ((char_index < 16) &&
                   (last_char != '+') &&
                   (last_char != '=') &&
                   (last_char < 'A') &&
@@ -422,18 +427,18 @@ void process_text(const char *text, sink_t *consumer)
               else if (char_index > 26)
                 {
                   uint8_t prev = sink_last(consumer);
-                  if (((c != '+') && (c != '=')) || (prev > 5))
+                  if (((c != '+') && (c != '=')) || (prev > PH_I))
                     {
-                      if ((prev < 43) || (prev > 52))
-                        sink_put(consumer, 43);
+                      if ((prev < PH_SPACE) || (prev > PH_MINUS))
+                        sink_put(consumer, PH_SPACE);
                       put_transcription_block(consumer, char_index);
                       if ((c != '-') && (input.start[1] >= 'A'))
-                        sink_put(consumer, 43);
+                        sink_put(consumer, PH_SPACE);
                       transcription->flags |= CLAUSE_START;
                     }
                   else
                     {
-                      sink_put(consumer, (c != '+') ? 54 : 53);
+                      sink_put(consumer, (c != '+') ? PH_SECONDARY_STRESS  : PH_PRIMARY_STRESS);
                       transcription->flags &= ~CLAUSE_START;
                     }
                   last_char = c;
@@ -516,9 +521,9 @@ void process_text(const char *text, sink_t *consumer)
           s = strchr(vocalics, c);
           if (s)
             {
-              uint8_t vc = (c == 'I') ? 5 :
+              uint8_t vc = (c == 'I') ? PH_I :
                 (((c == 'O') &&accented && (input.start[1] != '+') && (input.start[1] != '=')) ?
-                 2 : vocal_phoncodes[(s - vocalics) % 5]);
+                 PH_A : vocal_phoncodes[(s - vocalics) % 5]);
               transcription->flags &= ~CLAUSE_START;
               if (input.start > input.text)
                 {
@@ -528,13 +533,13 @@ void process_text(const char *text, sink_t *consumer)
                       if ((strchr(vocalics, prevc) || memchr(symbols, prevc, 13) ||
                            (prevc == ']')) &&
                           strchr("`QE\\", c))
-                        sink_put(consumer, 10);
+                        sink_put(consumer, PH_J);
                     }
                   else if (strchr("`QE\\IO", c))
-                    sink_put(consumer, 10);
+                    sink_put(consumer, PH_J);
                 }
               else if (strchr("`QE\\", c))
-                sink_put(consumer, 10);
+                sink_put(consumer, PH_J);
               sink_put(consumer, vc);
               last_char = c;
               continue;
@@ -570,7 +575,7 @@ void process_text(const char *text, sink_t *consumer)
                 {
                   input.start++;
                   nextc = ((input.end - input.start) > 1) ? input.start[1] : ',';
-                  if ((memchr(symbols + 1, nextc, 6) && (sink_last(consumer) != 43)) || memchr(consonants + 5, nextc, 10))
+                  if ((memchr(symbols + 1, nextc, 6) && (sink_last(consumer) != PH_SPACE)) || memchr(consonants + 5, nextc, 10))
                     sink_put(consumer, unvoicify(soft_consonant_phs, idx));
                   else if (strchr(bgdjz, nextc))
                     sink_put(consumer, voicify(soft_consonant_phs, idx));
@@ -579,13 +584,13 @@ void process_text(const char *text, sink_t *consumer)
               else if (memchr(vocalics, nextc, 5))
                 sink_put(consumer, soft_consonant_phs[idx]);
               else if (memchr(symbols + 1, nextc, 6))
-                sink_put(consumer, (sink_last(consumer) != 43) ? unvoicify_hard(idx, nextc) : hard_consonant_phs[idx]);
+                sink_put(consumer, (sink_last(consumer) != PH_SPACE) ? unvoicify_hard(idx, nextc) : hard_consonant_phs[idx]);
               else sink_put(consumer, correct_consonant(idx, (nextc != ' ') ? nextc : input.start[2]));
             }
           else if (c != ']')
             {
               transcription->flags |= CLAUSE_START;
-              sink_put(consumer, (c != '#') ? 43 : 42);
+              sink_put(consumer, (c != '#') ? PH_SPACE : PH_TERMINATOR);
             }
           else transcription->flags &= ~CLAUSE_START;
           last_char = c;

--- a/src/utterance.c
+++ b/src/utterance.c
@@ -13,6 +13,7 @@
 
 #include "soundscript.h"
 #include "transcription.h"
+#include "phonemes.h"
 
 
 /* Local data */
@@ -62,22 +63,22 @@ static void put_sound(soundscript_t *script, uint8_t sound, uint8_t stage)
 void build_utterance(uint8_t *transcription, soundscript_t *script)
 {
   uint16_t i = TRANSCRIPTION_START;
-  uint8_t a = 43;
+  uint8_t a = PH_SPACE;
   uint8_t c = transcription[i];
 
-  while ((a < 44) && (i < TRANSCRIPTION_BUFFER_SIZE))
+  while ((a < PH_COMMA) && (i < TRANSCRIPTION_BUFFER_SIZE))
     {
       uint8_t flags = 0;
       uint16_t j;
 
       for (j = i; j < TRANSCRIPTION_BUFFER_SIZE; j++)
-        if (transcription[j] != 43)
+        if (transcription[j] != PH_SPACE)
           {
-            if (transcription[j] < 43)
+            if (transcription[j] < PH_SPACE)
               for (j++; j < TRANSCRIPTION_BUFFER_SIZE; j++)
-                if (transcription[j] > 42)
+                if (transcription[j] > PH_TERMINATOR)
                   {
-                    if ((transcription[j] == 53) || (transcription[j] == 54))
+                    if ((transcription[j] == PH_PRIMARY_STRESS) || (transcription[j] == PH_SECONDARY_STRESS))
                       flags |= 2;
                     break;
                   }
@@ -88,54 +89,54 @@ void build_utterance(uint8_t *transcription, soundscript_t *script)
         {
           uint8_t b = a;
           a = c;
-          if (a > 43)
+          if (a > PH_SPACE)
             break;
           flags &= ~1;
 
           while (i < TRANSCRIPTION_BUFFER_SIZE)
             {
               c = transcription[++i];
-              if (c < 53)
+              if (c < PH_PRIMARY_STRESS)
                 break;
               flags |= 1;
             }
 
-          if (a == 43)
+          if (a == PH_SPACE)
             {
               put_sound(script, 190, 2);
               break;
             }
-          else if (a > 5)
+          else if (a > PH_I)
             {
-              if (a > 13)
+              if (a > PH_R_)
                 {
-                  if (a > 19)
+                  if (a > PH_N_)
                     {
-                      if (a > 31)
+                      if (a > PH_K_)
                         {
-                          if (a > 41)
+                          if (a > PH_X_)
                             put_sound(script, 189, 2);
-                          else if (a < 34)
+                          else if (a < PH_F)
                             {
                               put_sound(script, a + 143, 2);
                               put_sound(script, a + 145, 3);
                             }
-                          else if ((a < 40) || (a == 41) || (c > 5))
+                          else if ((a < PH_X) || (a == PH_X_) || (c > PH_V))
                             put_sound(script, a + 145, 2);
                           else put_sound(script, a + soundset4[c], 2);
                         }
                       else
                         {
                           put_sound(script, a + 143, 2);
-                          if (a < 29)
+                          if (a < PH_P_)
                             {
-                              if (a < 26)
+                              if (a < PH_P)
                                 {
-                                  if ((a < 23) && (c < 6))
+                                  if ((a < PH_B_) && (c < PH_V))
                                     put_sound(script, a + soundset3[c], 3);
                                   else put_sound(script, a + 119, 3);
                                 }
-                              else if (c < 6)
+                              else if (c < PH_V)
                                 put_sound(script, a + soundset3[c], 3);
                               else put_sound(script, a + 119, 3);
                             }
@@ -146,12 +147,12 @@ void build_utterance(uint8_t *transcription, soundscript_t *script)
                 }
               else
                 {
-                  if (b > 13)
+                  if (b > PH_R_)
                     put_sound(script, a + 99, 1);
-                  if ((a != 10) || (transcription[i + 1] > 52) || ((c > 5) && (c < 44)))
+                  if ((a != PH_J) || (transcription[i + 1] > PH_MINUS) || ((c > PH_I) && (c < PH_COMMA   )))
                     {
                       put_sound(script, a + 117, 2);
-                      if (c > 13)
+                      if (c > PH_R_)
                         put_sound(script, a + 99, 3);
                     }
                   else put_sound(script, 122, 2);
@@ -160,58 +161,58 @@ void build_utterance(uint8_t *transcription, soundscript_t *script)
           else
             {
               j = 90;
-              if (b > 5)
+              if (b > PH_I)
                 {
-                  if (b < 42)
+                  if (b < PH_TERMINATOR)
                     j = soundset2[b - 6];
-                  if (a == 5)
+                  if (a == PH_I)
                     j--;
                 }
-              else j = (a != 5) ? 95 : 99;
+              else j = (a != PH_I) ? 95 : 99;
               put_sound(script, a + j, 1);
               if (flags != 2)
                 {
-                  if ((b > 5) && (b < 42))
+                  if ((b > PH_I) && (b < PH_TERMINATOR))
                     {
                       j = soundset1[b - 6];
-                      if (a == 5)
+                      if (a == PH_I)
                         j--;
                     }
-                  else j = (a != 5) ? 0 : 4;
+                  else j = (a != PH_I) ? 0 : 4;
                   put_sound(script, a + j, 2);
                 }
-              if ((b > 5) && (b < 42))
-                put_sound(script, a + soundset1[b - 6] + ((a != 5) ? 95 : 94), 3);
-              else put_sound(script, a + ((a != 5) ? 95 : 99), 3);
-              if (c > 5)
+              if ((b > PH_I) && (b < PH_TERMINATOR))
+                put_sound(script, a + soundset1[b - 6] + ((a != PH_I) ? 95 : 94), 3);
+              else put_sound(script, a + ((a != PH_I) ? 95 : 99), 3);
+              if (c > PH_I)
                 {
-                  if (c != 42)
+                  if (c != PH_TERMINATOR)
                     {
-                      if (c == 43)
+                      if (c == PH_SPACE)
                         {
                           j = transcription[i + 1];
-                          if (j > 5)
+                          if (j > PH_I)
                             {
-                              if (j < 42)
-                                put_sound(script, a + soundset2[j - 6] + ((a != 5) ? 5 : 4), 4);
-                              else put_sound(script, a + ((a != 5) ? 90 : 89), 4);
+                              if (j < PH_TERMINATOR)
+                                put_sound(script, a + soundset2[j - 6] + ((a != PH_I) ? 5 : 4), 4);
+                              else put_sound(script, a + ((a != PH_I) ? 90 : 89), 4);
                             }
-                          else if (b > 5)
-                            put_sound(script, a + ((a != 5) ? 95 : 99), 4);
+                          else if (b > PH_I)
+                            put_sound(script, a + ((a != PH_I) ? 95 : 99), 4);
                         }
-                      else if (c > 43)
-                        put_sound(script, a + ((a != 5) ? 90 : 89), 4);
-                      else put_sound(script, a + soundset2[c - 6] + ((a != 5) ? 5 : 4), 4);
+                      else if (c > PH_SPACE)
+                        put_sound(script, a + ((a != PH_I) ? 90 : 89), 4);
+                      else put_sound(script, a + soundset2[c - 6] + ((a != PH_I) ? 5 : 4), 4);
                     }
-                  else put_sound(script, a + ((a != 5) ? 90 : 89), 4);
+                  else put_sound(script, a + ((a != PH_I) ? 90 : 89), 4);
                 }
-              else if (b > 5)
-                put_sound(script, a + ((a != 5) ? 95 : 99), 4);
+              else if (b > PH_I)
+                put_sound(script, a + ((a != PH_I) ? 95 : 99), 4);
             }
         }
     }
 
   if (i >= TRANSCRIPTION_BUFFER_SIZE)
-    a = 44;
+    a = PH_COMMA;
   put_sound(script, a + 147, 2);
 }


### PR DESCRIPTION
Added proper phoneme naming. Phonemes are now represented as human-readable names rather than numeric values. Everywhere in the code where numbers, letters, or symbols were hardcoded as digits, I have rewritten them into a readable format.
Added the phonemes.h file.
The phonemes are named as follows:
```C
PH_L = 14,  /* [л] */
PH_M = 15,  /* [м] */
PH_N = 16,  /* [н] */
PH_L_ = 17, /* [л'] */
PH_M_ = 18, /* [м'] */
PH_N_ = 19, /* [н'] */
```
An underscore at the end of the name indicates a soft (palatalized) phoneme.
If this naming convention is not suitable, let me know, and we can discuss it—or feel free to suggest an alternative format, and I will update it accordingly.
Example from numerics.c:
```c
static const uint8_t primary[] = /* 0..9 */
  {
    4, PH_N, PH_O, PH_PRIMARY_STRESS, PH_L_,
    5, PH_A, PH_D_, PH_I, PH_PRIMARY_STRESS, PH_N,
    4, PH_D, PH_V, PH_A, PH_PRIMARY_STRESS,
    4, PH_T, PH_R_, PH_I, PH_PRIMARY_STRESS,
    7, PH_CH, PH_E, PH_T, PH_Y, PH_PRIMARY_STRESS, PH_R_, PH_E,
    4, PH_P_, PH_A, PH_PRIMARY_STRESS, PH_T_,
    5, PH_SH, PH_E, PH_PRIMARY_STRESS, PH_S_, PH_T_,
    4, PH_S_, PH_E, PH_PRIMARY_STRESS, PH_M,
    6, PH_V, PH_O, PH_PRIMARY_STRESS, PH_S_, PH_E, PH_M,
    6, PH_D_, PH_E, PH_PRIMARY_STRESS, PH_V_, PH_A, PH_T_
  };
```