### PR TITLE
fix errors

### DIFF
--- a/src/soundproducer.c
+++ b/src/soundproducer.c
@@ -218,6 +218,9 @@ void make_sound(soundscript_t *script, sink_t *consumer, int rate_factor, int us
               while (l > ax)
                 {
                   k = script->icb[stage].stretch;
+                  /* Prevent zero from wrapping to UINT16_MAX in the do/while counter. */
+                  if (!k)
+                    k = 1;
                   do
                     {
                       sink_put(consumer, script->voice->samples[sidx++]);
@@ -241,6 +244,9 @@ void make_sound(soundscript_t *script, sink_t *consumer, int rate_factor, int us
                 {
                   uint16_t next_pattern_offset;
                   k = script->icb[stage].stretch;
+                  /* Prevent zero from wrapping to UINT16_MAX in the do/while counter. */
+                  if (!k)
+                    k = 1;
                   j = ((uint16_t)(script->sounds[i + 1].id)) & 0xFF;
                   next_pattern_offset = script->voice->sound_offsets[j + 1];
                   j = script->voice->sound_offsets[j];

--- a/src/text2speech.c
+++ b/src/text2speech.c
@@ -62,7 +62,7 @@ RUTTS_EXPORT void ru_tts_transfer(const ru_tts_conf_t *config,
 
   if (transcription_buffer)
     {
-      ttscb_t ttscb;
+      ttscb_t ttscb = {0};
       sink_t transcription_consumer;
 
       /* Initialize data structures */

--- a/src/utterance.c
+++ b/src/utterance.c
@@ -121,7 +121,7 @@ void build_utterance(uint8_t *transcription, soundscript_t *script)
                               put_sound(script, a + 143, 2);
                               put_sound(script, a + 145, 3);
                             }
-                          else if ((a < PH_X) || (a == PH_X_) || (c > PH_V))
+                          else if ((a < PH_X) || (a == PH_X_) || (c > PH_I))
                             put_sound(script, a + 145, 2);
                           else put_sound(script, a + soundset4[c], 2);
                         }


### PR DESCRIPTION
soundproducer: fix multi-second silence, text2speech: zero initialization of ttscb_t, utterance: previously introduced correction for the transition from the phoneme [х] to [в]